### PR TITLE
Fix incorrect socket-proxy example

### DIFF
--- a/docs/pages/misc/proxy.md
+++ b/docs/pages/misc/proxy.md
@@ -20,4 +20,4 @@ You need to enable the following (possibly more based on the version, future add
     - VOLUMES=1
 ```
 
-You also need to make sure and use the `DOCKER_HOST` variable (--env or compose environment) with the example value `http://socket-proxy:2375` (this points to your socket-proxy container)
+You also need to make sure and use the `DOCKER_HOST` variable (--env or compose environment) with the example value `tcp://socket-proxy:2375` (this points to your socket-proxy container)


### PR DESCRIPTION
fixed incorrect example value for DOCKER_HOST in socket-proxy info page.